### PR TITLE
Enhance backend preparation and Maven command handling with dynamic Spring profile support

### DIFF
--- a/window-ps7/NgBootStart/NgBootStart.ps1
+++ b/window-ps7/NgBootStart/NgBootStart.ps1
@@ -1,3 +1,18 @@
+# QuickStart Brand Display
+
+Clear-Host
+$brandName = "QuickStart"
+
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host "         WELCOME TO $brandName         " -ForegroundColor Yellow
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Empowering your journey with speed and innovation!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Visit us at: https://github.com/otaku0304/QuickStart" -ForegroundColor Magenta
+Write-Host ""
+Write-Host "--------------------------------------" -ForegroundColor DarkCyan
+
 # === CONFIG ===
 $backendPath = "C:\Path\To\Your\SpringBootProject" 
 $frontendPath = "C:\Path\To\Your\AngularOrReactProject"


### PR DESCRIPTION
This PR improves the backend startup script by introducing flexible handling of Spring Boot profiles when running the application via Maven. The key enhancements include:

- Added a $springProfile configuration variable to specify the active Spring profile (e.g., dev, prod, or empty for default).

- Updated Maven command generation to conditionally include the --spring.profiles.active argument only when a profile is provided.